### PR TITLE
Added functionality to specify a port

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ cd /path/to/site
 angular-http-server
 ```
 
+## You can also (optionally) specify a port as well:
+
+```
+angular-http-server -p 8080
+```
+
 And browse to `localhost:8080`.
 
 Feedback via: https://github.com/simonh1000/angular-http-server

--- a/angular-http-server.js
+++ b/angular-http-server.js
@@ -2,6 +2,7 @@
 
 var http = require("http");
 var fs = require("fs");
+var argv = require('minimist')(process.argv.slice(2));
 
 var server = http.createServer(function (req, res) {
     // console.log(req.url);
@@ -33,6 +34,19 @@ var server = http.createServer(function (req, res) {
     });
 });
 
+function getPort() {
+  if (argv.p) {
+    var portNum = parseInt(argv.p);
+    if (!isNaN(portNum)) {
+      return portNum;
+    } else {
+      throw new Exception("Provided port number is not a number!");
+    }
+  }else {
+    return 8080;
+  }
+}
+
 function toMimeType(ext) {
     // console.log(ext);
     // if (fileExtension == "css") {
@@ -48,4 +62,4 @@ function toMimeType(ext) {
             return 'text/' + ext;
     }
 }
-server.listen(8080, function () { return console.log("Listening on 8080"); });
+server.listen(getPort(), function () { return console.log("Listening on " + getPort()); });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-http-server",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "author": "Simon Hampton",
   "license": "ISC",
   "description": "Simple http server for developers that supports apps with client side routing, such as Angular",
@@ -15,9 +15,18 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "contributors": [
+    {
+      "name": "Dale Myszewski",
+      "email": "dale@daleslab.com"
+    }
+  ],
   "engine": "0.12.x",
   "preferGlobal": true,
   "bin": {
     "angular-http-server": "./angular-http-server.js"
+  },
+  "dependencies": {
+    "minimist": "^1.2.0"
   }
 }


### PR DESCRIPTION
First off fantastic accomplished exactly what I needed - serve an Angular SPA site with no overly fancy bells and whistles.

But there was a feature I found that it lacked which made it impossible to use on our internal Dokku server - that was the lack of ability to specify a port. Since Dokku manages the port for you in the Procfile by you passing $PORT as a parameter it was causing a bit of chaos.

What I added - a library to make it a little easier to parse out CLI arguments. Then there is one added function which checks for the presence of the argument and if it's a number. If the argument is present and it is a number it will be passed as the return value which is then used by server.listen.

If the port argument is not present the default 8080 port is returned and if the argument is present but not a number an exception will be thrown.

I also went ahead and bumped the version number as well.