### PR TITLE
Add SSL support via --https or --ssl toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,28 @@ Other simple http-servers (correctly) give a 404 when you try to refresh your br
 
 ## To use:
 
-```
+```sh
 npm install -g angular-http-server
 cd /path/to/site
 angular-http-server
 ```
 
-## You can also (optionally) specify a port as well:
+## Options
 
-```
+Specify a port using `-p <port number>`
+
+```sh
 angular-http-server -p 8080
 ```
 
 And browse to `localhost:8080`.
+
+
+HTTPS can be enabled (using a generated self-signed certificate) with `--https` or `--ssl`
+```sh
+angular-http-server --https
+```
+
 
 Feedback via: https://github.com/simonh1000/angular-http-server
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ angular-http-server --cors
 
 Feedback via: https://github.com/simonh1000/angular-http-server
 
+## HTTPS Rationale
+
+If you're using `angular-http-server` in production, you wouldn't use a self-signed SSL certificate, so
+do not use `--https` or `--ssl` flags for production. Instead, run `angular-http-server` in http mode
+and forward traffic to it from an SSL-enabled reverse-proxy server (for instance, you can set one
+up with [NGINX](https://www.nginx.com/resources/admin-guide/reverse-proxy/))
+
+If you're only using `angular-http-server` for development or testing, a self-signed SSL certificate
+is fine. For example, end-to-end tests with [Protractor](http://www.protractortest.org/) require the
+Angular application to be actively served, which can be done using a background `angular-http-server`.
+If your end-to-end testing suite requires your application be served over HTTPS, the self-signed
+certificate generated when you pass the `--https`/`--ssl` flag will work fine to provide that.
+
 ## To develop
 
 http://justjs.com/posts/npm-link-developing-your-own-npm-modules-without-tears

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ HTTPS can be enabled (using a generated self-signed certificate) with `--https` 
 angular-http-server --https
 ```
 
+[CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) can be enabled with the --cors flag
+```sh
+angular-http-server --cors
+```
+
 
 Feedback via: https://github.com/simonh1000/angular-http-server
 

--- a/angular-http-server.js
+++ b/angular-http-server.js
@@ -1,10 +1,29 @@
 #!/usr/bin/env node
 
-var http = require("http");
 var fs = require("fs");
 var argv = require('minimist')(process.argv.slice(2));
 
-var server = http.createServer(function (req, res) {
+var server;
+if (argv.ssl || argv.https) {
+    var pem = require('pem');
+    var https = require('https');
+    pem.createCertificate({days: 1, selfSigned: true}, function(err, keys) {
+        var options = {
+            key: keys.serviceKey,
+            cert: keys.certificate,
+            rejectUnauthorized: false
+        };
+        server = https.createServer(options, requestListener);
+        start();
+    });
+}
+else {
+    var http = require("http");
+    server = http.createServer(requestListener);
+    start();
+}
+
+function requestListener(req, res) {
     // console.log(req.url);
     var url = req.url.split('?')[0]
     var possibleFilename = url.slice(1) || "dummy";
@@ -32,7 +51,7 @@ var server = http.createServer(function (req, res) {
         res.write(fileBuffer);
         res.end();
     });
-});
+}
 
 function getPort() {
     if (argv.p) {
@@ -57,4 +76,8 @@ function toMimeType(ext) {
             return 'text/' + ext;
     }
 }
-server.listen(getPort(), function () { return console.log("Listening on " + getPort()); });
+
+function start() {
+  server.listen(getPort(), function () { return console.log("Listening on " + getPort()); });
+}
+

--- a/angular-http-server.js
+++ b/angular-http-server.js
@@ -28,6 +28,18 @@ function requestListener(req, res) {
     var url = req.url.split('?')[0]
     var possibleFilename = url.slice(1) || "dummy";
 
+    if (argv.cors) {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Access-Control-Request-Method', '*');
+      res.setHeader('Access-Control-Allow-Methods', 'OPTIONS, GET');
+      res.setHeader('Access-Control-Allow-Headers', 'authorization, content-type');
+      if ( req.method === 'OPTIONS' ) {
+        res.writeHead(200);
+        res.end();
+        return;
+      }
+    }
+
     fs.stat(possibleFilename, function (err, stats) {
 
         var fileBuffer;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-http-server",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "Simon Hampton",
   "license": "ISC",
   "description": "Simple http server for developers that supports apps with client side routing, such as Angular",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-http-server",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "Simon Hampton",
   "license": "ISC",
   "description": "Simple http server for developers that supports apps with client side routing, such as Angular",

--- a/package.json
+++ b/package.json
@@ -21,12 +21,15 @@
       "email": "dale@daleslab.com"
     }
   ],
-  "engines" : { "node" : ">=4.0.0" },
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "preferGlobal": true,
   "bin": {
     "angular-http-server": "./angular-http-server.js"
   },
   "dependencies": {
-    "minimist": "^1.2.0"
+    "minimist": "^1.2.0",
+    "pem": "^1.9.7"
   }
 }


### PR DESCRIPTION
Adds command line arguments --https and --ssl to enable serving over HTTPS. 

Self-signed SSL certificates are created on-the-fly with [pem](https://www.npmjs.com/package/pem), added as a dependency.