### PR TITLE
Added option to open automatically in a default browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ angular-http-server
 
 And browse to `localhost:8080`.
 
+Open in a default browser automatically by using `--open` alias `-o`
+
+```sh
+angular-http-server --open
+```
+
 ## Options
 
 Specify a port using `-p <port number>`
@@ -23,6 +29,8 @@ Specify a port using `-p <port number>`
 ```sh
 angular-http-server -p 9000
 ```
+
+
 
 HTTPS can be enabled (using a generated self-signed certificate) with `--https` or `--ssl`
 

--- a/angular-http-server.js
+++ b/angular-http-server.js
@@ -7,6 +7,9 @@ var path = require("path");
 var pem = require('pem');
 var https = require('https');
 var http = require("http");
+var opn = require('opn');
+
+
 
 var server;
 
@@ -34,6 +37,9 @@ if (argv.ssl || argv.https) {
 
 function start() {
     server.listen(getPort(), function () {
+        if(argv.open == true || argv.o) {
+            opn(((argv.ssl)?'https':'http')+"://localhost:"+getPort());
+        }
         return console.log("Listening on " + getPort());
     });
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "dependencies": {
         "mime": "^1.3.6",
         "minimist": "^1.2.0",
+        "opn": "^5.3.0",
         "pem": "^1.9.7"
     }
 }


### PR DESCRIPTION
I have added an option to open the localhost link in the user's default browser. Copying the feature of ng-serve --open which does the same thing.