### PR TITLE
Auto increment port when the specified port or default port is busy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ And browse to `localhost:8080`.
 
 ## Options
 
-Specify a port using `-p <port number>`
+Specify a port using `-p <port number>`<br>
+Note: When the default port or specified port is busy, it automatically keep incrementing untill it sees a usable port to listen.
 
 ```sh
 angular-http-server -p 9000


### PR DESCRIPTION
If the port is busy, keep incrementing the port until it sees a usable port to ease the port conflict handling.