### PR TITLE
Added option for configuration of the baseHref of the application

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ Specify a path to serve from
 angular-http-server --path example
 ```
 
+Specify the base href of the application
+```sh
+angular-http-server --baseHref myapp
+```
+
 Disable logging
 ```sh
 angular-http-server --silent

--- a/lib/angular-http-server.js
+++ b/lib/angular-http-server.js
@@ -36,6 +36,7 @@ if (argv.config) {
 // Pre-process arguments
 const useHttps = argv.ssl || argv.https;
 const basePath = argv.path ? path.resolve(argv.path) : process.cwd();
+const baseHref = argv.baseHref ? argv.baseHref : '';
 const port = getPort(argv.p);
 
 // As a part of the startup - check to make sure we can access index.html
@@ -99,7 +100,7 @@ function requestListener(req, res) {
         }
     }
 
-    const safeFullFileName = getFilePathFromUrl(req.url, basePath);
+    const safeFullFileName = getFilePathFromUrl(req.url, basePath, { baseHref });
 
     fs.stat(safeFullFileName, function(err, stats) {
         var fileBuffer;

--- a/lib/get-file-path-from-url.js
+++ b/lib/get-file-path-from-url.js
@@ -8,7 +8,7 @@ const path = require('path');
  * @param {object} [pathLib=path] - path library, override for testing
  * @return {string} - will return 'dummy' if the path is bad
  */
-function getFilePathFromUrl(url, basePath, { pathLib = path } = {}) {
+function getFilePathFromUrl(url, basePath, { pathLib = path, baseHref = '' } = {}) {
   if (!basePath) {
     throw new Error('basePath must be specified');
   }
@@ -16,11 +16,19 @@ function getFilePathFromUrl(url, basePath, { pathLib = path } = {}) {
     throw new Error(`${basePath} is invalid - must be absolute`);
   }
 
-  const relativePath = url.split('?')[0];
+  let relativePath = url.split('?')[0];
 
   if (relativePath.indexOf('../') > -1) {
     // any path attempting to traverse up the directory should be rejected
     return 'dummy';
+  }
+
+  if (baseHref) {
+    if (relativePath.startsWith('/' + baseHref)) {
+      relativePath = relativePath.substr(baseHref.length + 1)
+    } else {
+      return 'dummy'
+    }
   }
 
   const absolutePath = pathLib.join(basePath, relativePath);

--- a/lib/get-file-path-from-url.spec.js
+++ b/lib/get-file-path-from-url.spec.js
@@ -65,11 +65,31 @@ describe('getFilePathFromUrl', () => {
     });
   }
 
+  function testWithBaseHref(pathLib, basePath) {
+    const baseHref = 'myapp';
+    context (`where baseHref = "${baseHref}" and basePath = "${basePath}"`, () => {
+      function createTest(input, expected) {
+        it(`should return "${expected}" given input "${input}"`, () => {
+          expect(getFilePathFromUrl(input, basePath, { pathLib, baseHref})).to.equal(expected)
+        });
+      }
+      function expectPath(input, expected) {
+        createTest(input, pathLib.join(basePath, expected).split('?')[0]);
+      }
+      function expectDummy(input, expected) {
+        createTest(input, 'dummy');
+      }
+      expectPath('/myapp/test.js', 'test.js');
+      expectDummy('/test.js');
+    });
+  }
+
   context('on a Windows system', () => {
     const pathLib = path.win32;
 
     testInvalidBasePaths(pathLib, ['dist\\output', '.\\', '.', '.\\serve']);
     testValidBasePaths(pathLib, ['C:\\', 'C:\\project', 'C:\\project\\serve\\output']);
+    testWithBaseHref(pathLib, 'C:\\project');
   });
 
   context('on a POSIX system', () => {
@@ -77,5 +97,6 @@ describe('getFilePathFromUrl', () => {
 
     testInvalidBasePaths(pathLib, ['dist/output', './', '.', './serve']);
     testValidBasePaths(pathLib, ['/', '/home', '/home/user/project/serve/output']);
+    testWithBaseHref(pathLib, '/home/user/project');
   });
 });


### PR DESCRIPTION
This allows us to serve our angular app, which has a specific base href, from the dist folder for our cypress tests instead of using ng serve. 