### PR TITLE
Add support for deflate and gzip compression

### DIFF
--- a/lib/angular-http-server.js
+++ b/lib/angular-http-server.js
@@ -7,12 +7,15 @@ var pem = require("pem");
 var https = require("https");
 var http = require("http");
 var opn = require("opn");
+var zlib = require('zlib');
 
 var argv = require("minimist")(process.argv.slice(2));
 const getFilePathFromUrl = require('./get-file-path-from-url');
 
 const NO_PATH_FILE_ERROR_MESSAGE =
     "Error: index.html could not be found in the specified path ";
+
+const COMPRESSIBLE_CONTENT_TYPES = ['application/javascript', 'application/json', 'text/html', 'text/css'];
 
 // if using config file, load that first
 if (argv.config) {
@@ -72,7 +75,7 @@ if (useHttps) {
 }
 
 function start() {
-    server.listen(port, function() {
+    server.listen(port, function () {
         if (argv.open == true || argv.o) {
             opn((useHttps ? "https" : "http") + "://localhost:" + port);
         }
@@ -102,22 +105,62 @@ function requestListener(req, res) {
 
     const safeFullFileName = getFilePathFromUrl(req.url, basePath, { baseHref });
 
-    fs.stat(safeFullFileName, function(err, stats) {
-        var fileBuffer;
+    fs.stat(safeFullFileName, function (err, stats) {
         if (!err && stats.isFile()) {
-            fileBuffer = fs.readFileSync(safeFullFileName);
-            let ct = mime.lookup(safeFullFileName);
+            const ct = mime.lookup(safeFullFileName);
+            const acceptEncoding = req.headers['accept-encoding'] || '';
+
             log(`Sending ${safeFullFileName} with Content-Type ${ct}`);
-            res.writeHead(200, { "Content-Type": ct });
+
+            if (contentIsCompressible(ct, acceptEncoding)) {
+                sendCompressedResponse(res, ct, acceptEncoding, safeFullFileName);
+            } else {
+                const raw = fs.createReadStream(safeFullFileName);
+                res.writeHead(200, {
+                    "Content-Type": ct
+                });
+                raw.pipe(res);
+            }
         } else {
             log("Route %s, replacing with index.html", safeFullFileName);
-            fileBuffer = returnDistFile();
             res.writeHead(200, { "Content-Type": "text/html" });
+            res.write(returnDistFile());
+            res.end();
         }
-
-        res.write(fileBuffer);
-        res.end();
     });
+}
+
+function contentIsCompressible(contentType, acceptEncoding) {
+    // Note: This is not a conformant accept-encoding parser.
+    // See https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3
+    if (COMPRESSIBLE_CONTENT_TYPES.includes(contentType)
+        && (
+            /\bdeflate\b/.test(acceptEncoding) ||
+            /\bgzip\b/.test(acceptEncoding)
+        )) {
+        return true;
+    }
+    return false;
+}
+
+function sendCompressedResponse(res, contentType, encoding, safeFullFileName) {
+    const raw = fs.createReadStream(safeFullFileName);
+
+    if (/\bgzip\b/.test(encoding)) {
+        res.writeHead(200, {
+            "Content-Encoding": "gzip",
+            "Content-Type": contentType
+        });
+        raw.pipe(zlib.createGzip()).pipe(res);
+    } else if (/\bdeflate\b/.test(encoding)) {
+        res.writeHead(200, {
+            "Content-Type": "deflate",
+            "Content-Type": contentType
+        });
+        raw.pipe(zlib.createDeflate()).pipe(res);
+    } else {
+        log("Unsupported encoding: ", encoding);
+    }
 }
 
 function getPort(portNo) {


### PR DESCRIPTION
closes: https://github.com/simonh1000/angular-http-server/issues/26

This change is to add compression (gzip and deflate) support for content `['application/javascript', 'application/json', 'text/html', 'text/css']` automatically (without a command line switch) based on the `Accept-Encoding` request header entry.

Didn't have much time to write the tests but, my instinct tells me it works. Might need  a bit of optimization here and there. 