### PR TITLE
Proxy config secure flag

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -41,7 +41,7 @@ function proxyHandler(req, res, configs) {
                 );
 
                 if (proxyServer === null) {
-                    proxyServer = httpProxy.createProxyServer({});
+                    proxyServer = httpProxy.createProxyServer({secure: config.secure === undefined ? true : config.secure});
                 }
 
                 proxyServer.web(req, res, {

--- a/lib/proxy.spec.js
+++ b/lib/proxy.spec.js
@@ -44,7 +44,7 @@ describe("proxyHandler", () => {
         });
 
         expect(() => proxyHandler(req, {}, null, false)).to.throw(
-            "no proxyConfig present, please configure in your config file"
+            "no proxy configs present, please configure in your config file"
         );
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "angular-http-server",
-    "version": "1.10.1",
+    "version": "1.11.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "angular-http-server",
-            "version": "1.10.1",
+            "version": "1.11.1",
             "license": "ISC",
             "dependencies": {
                 "http-proxy": "^1.18.1",
@@ -24,7 +24,7 @@
                 "node-mocks-http": "^1.11.0"
             },
             "engines": {
-                "node": ">=8.0.0"
+                "node": ">=10.0.0"
             }
         },
         "node_modules/accepts": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
         },
         {
             "name": "AVierwind"
+        },
+        {
+            "name": "tomtucker18"
         }
     ],
     "engines": {


### PR DESCRIPTION
Adds new option **secure** to the config. Allows HTTPS requests to self-signed certificates.
The secure flag is set to true if it isn't configured. In that way the behavior stays the same as it was before this change.

Closes Issue #54 