### PR TITLE
add support for websocket requests

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -46,6 +46,7 @@ function proxyHandler(req, res, configs) {
 
                 proxyServer.web(req, res, {
                     target: `${protocol}://${config.target}`,
+                    ws: protocol === 'ws' || protocol === 'wss'
                 }, (e, req, res) => {
                     console.error(`Proxy error: ${e.code}`);
                     res.writeHead(502);


### PR DESCRIPTION
GraphQL subscriptions do not work on my project by just setting protocol to ws. The parameter ws: true has to be set.